### PR TITLE
Fix for zero preview

### DIFF
--- a/request.go
+++ b/request.go
@@ -146,7 +146,7 @@ func ReadRequest(b *bufio.ReadWriter) (req *Request, err error) {
 		if p := req.Header.Get("Preview"); p != "" {
 			moreBody := false
 			
-			if previewSize, err := strconv.Atoi(p); err != nil && p > 0 {
+			if previewSize, err := strconv.Atoi(p); err != nil && previewSize > 0 {
 				moreBody = true
 			}
 			

--- a/request.go
+++ b/request.go
@@ -143,7 +143,7 @@ func ReadRequest(b *bufio.ReadWriter) (req *Request, err error) {
 
 	var bodyReader io.ReadCloser = emptyReader(0)
 	if hasBody {
-		if p := req.Header.Get("Preview"); p != "" {
+		if p := req.Header.Get("Preview"); p != "" && p != "0" {
 			moreBody := true
 			req.Preview, err = ioutil.ReadAll(newChunkedReader(b))
 			if err != nil {

--- a/request.go
+++ b/request.go
@@ -143,8 +143,13 @@ func ReadRequest(b *bufio.ReadWriter) (req *Request, err error) {
 
 	var bodyReader io.ReadCloser = emptyReader(0)
 	if hasBody {
-		if p := req.Header.Get("Preview"); p != "" && p != "0" {
-			moreBody := true
+		if p := req.Header.Get("Preview"); p != "" {
+			moreBody := false
+			
+			if previewSize, err := strconv.Atoi(p); err != nil && p > 0 {
+				moreBody = true
+			}
+			
 			req.Preview, err = ioutil.ReadAll(newChunkedReader(b))
 			if err != nil {
 				if strings.Contains(err.Error(), "ieof") {


### PR DESCRIPTION
When preview is '0', the icap library will still send a 100 continue.
This fixes that.